### PR TITLE
[Refactor] StatisticsProcessor: クライアントID付きメッセージの非同期ログ出力実装　TSK-34

### DIFF
--- a/Andean/Program.cs
+++ b/Andean/Program.cs
@@ -12,6 +12,7 @@ using Andean.WebsocketServer.Controllers;
 using Andean.AndeanClass.Controllers;
 using Andean.AndeanClass.Services;
 using Andean.WebsocketServer.Services;
+using Andean.AndeanClass.Services.Utilities;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -57,6 +58,8 @@ builder.Services.AddSingleton<IMatchService, MatchService>();
 // 🚀 ILobbyService をシングルトンで登録
 builder.Services.AddSingleton<ILobbyService, LobbyService>();
 
+// 🚀 FileOutputService をシングルトンで登録
+builder.Services.AddSingleton<FileOutputService>();
 
 
 

--- a/Andean/Services/Utilities/FileOutputService.cs
+++ b/Andean/Services/Utilities/FileOutputService.cs
@@ -1,0 +1,74 @@
+﻿using System.IO;
+using Newtonsoft.Json.Linq;  // JSON操作に Newtonsoft.Json を利用する場合
+
+namespace Andean.AndeanClass.Services.Utilities
+{
+    public enum FileWriteMode
+    {
+        Overwrite,  // 上書きモード
+        Append,     // 追記モード
+        JsonAppend  // JSON 追記モード（既存の JSON 配列に新しいオブジェクトを追加）
+    }
+
+    public class FileOutputService
+    {
+        /// <summary>
+        /// 指定されたパスとファイル名に対し、内容をモードに応じて書き込みます。
+        /// </summary>
+        /// <param name="path">出力先ディレクトリのパス</param>
+        /// <param name="fileName">出力するファイル名</param>
+        /// <param name="content">書き込む内容</param>
+        /// <param name="mode">書き込みモード (Overwrite, Append, JsonAppend)</param>
+        public void WriteToFile(string path, string fileName, string content, FileWriteMode mode)
+        {
+            // 出力先のディレクトリが存在しなければ作成
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
+
+            string fullPath = Path.Combine(path, fileName);
+
+            switch (mode)
+            {
+                case FileWriteMode.Overwrite:
+                    File.WriteAllText(fullPath, content);
+                    break;
+
+                case FileWriteMode.Append:
+                    File.AppendAllText(fullPath, content);
+                    break;
+
+                case FileWriteMode.JsonAppend:
+                    // JSON追記モードの場合、ファイルが存在していれば既存の JSON 配列に追加、なければ新たに JSON 配列を作成
+                    if (File.Exists(fullPath))
+                    {
+                        var existingJson = File.ReadAllText(fullPath);
+                        JArray jsonArray;
+                        try
+                        {
+                            jsonArray = JArray.Parse(existingJson);
+                        }
+                        catch
+                        {
+                            jsonArray = new JArray();
+                        }
+                        var newObj = JObject.Parse(content);
+                        jsonArray.Add(newObj);
+                        File.WriteAllText(fullPath, jsonArray.ToString());
+                    }
+                    else
+                    {
+                        var jsonArray = new JArray();
+                        var newObj = JObject.Parse(content);
+                        jsonArray.Add(newObj);
+                        File.WriteAllText(fullPath, jsonArray.ToString());
+                    }
+                    break;
+
+                default:
+                    throw new System.ArgumentException("Unknown FileWriteMode");
+            }
+        }
+    }
+}

--- a/Andean/WebsocketServer/Controllers/StatisticsProcessor.cs
+++ b/Andean/WebsocketServer/Controllers/StatisticsProcessor.cs
@@ -5,6 +5,7 @@ using Google.Protobuf;
 using Rtech.Liveapi;
 using Andean.AndeanClass.Services;
 using Andean.WebsocketServer.Services;
+using Andean.AndeanClass.Services.Utilities;
 
 namespace Andean.WebsocketServer.Controllers
 {
@@ -32,15 +33,26 @@ namespace Andean.WebsocketServer.Controllers
         private readonly IMatchService _matchService;
         private readonly ILobbyService _lobbyService;
         private readonly ClientManagementService _clientManagement;
+        private readonly FileOutputService _fileOutputService;
+
+        // ログ出力用ファイル名（サーバー起動時のタイムスタンプで固定）
+        private readonly string _logFileName;
 
         public StatisticsProcessor(
             IMatchService matchService,
             ILobbyService lobbyService,
-            ClientManagementService clientManagement)
+            ClientManagementService clientManagement,
+            FileOutputService fileOutputService)
         {
             _matchService = matchService;
             _lobbyService = lobbyService;
             _clientManagement = clientManagement;
+
+            _fileOutputService = fileOutputService;
+
+            // サーバー起動時のタイムスタンプでログファイル名を決定（例: 20250222_132800_log.txt）
+            _logFileName = DateTime.Now.ToString("yyyyMMdd_HHmmss") + "_log.txt";
+
             // 別スレッドでキュー処理を開始
             Task.Factory.StartNew(ProcessQueue, TaskCreationOptions.LongRunning);
         }
@@ -51,6 +63,12 @@ namespace Andean.WebsocketServer.Controllers
         public void EnqueueMessage(string clientId, IMessage message)
         {
             _queue.Add(new MessageWrapper(clientId, message));
+
+            // ログ出力用の文字列を作成
+            string logContent = $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Client: {clientId}, MessageType: {message.GetType().Name}, Content: {message}{Environment.NewLine}";
+
+            // 非同期にファイルへ追記（ファイルは ./output フォルダ配下に作成）
+            Task.Run(() => _fileOutputService.WriteToFile("./output", _logFileName, logContent, FileWriteMode.Append));
         }
 
         /// <summary>

--- a/Andean/output/20250304_231902_log.txt
+++ b/Andean/output/20250304_231902_log.txt
@@ -1,0 +1,1 @@
+[2025-03-04 23:19:56] Client: 1277bb38-312a-46d8-98da-208d99d461e3, MessageType: Init, Content: { "timestamp": "1741097996", "category": "init", "gameVersion": "Build ID: R5pc_r5-240_J25_CL8541224_2025_02_13_16_39", "apiVersion": { "majorNum": 2, "minorNum": 2, "buildStamp": 959516 }, "platform": "PC" }


### PR DESCRIPTION
- EnqueueMessage の引数にクライアントIDを追加し、MessageWrapper でメッセージとIDの組み合わせを管理
- FileOutputService を導入し、./output/{timestamp}_log.txt に追記モードで非同期にログを出力する機能を実装
- 受信メッセージの処理と同時に、メッセージ内容とクライアントIDがログに記録されるように変更