### PR TITLE
[Refactor] FileOutputService: JSON追記モードでのファイル読み込み処理を FileReadService に委譲 TSK-69

### DIFF
--- a/Andean/Services/Utilities/FileOutputService.cs
+++ b/Andean/Services/Utilities/FileOutputService.cs
@@ -1,25 +1,36 @@
-﻿using System.IO;
-using Newtonsoft.Json.Linq;  // JSON操作に Newtonsoft.Json を利用する場合
-
-namespace Andean.AndeanClass.Services.Utilities
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;  // JSON 操作用（Newtonsoft.Json を使用）
+using System.Text.Json;      // 例として、System.Text.Json を使う場合もあり
+// 名前空間はプロジェクトに合わせて設定してください
+namespace Andean.Services.Utilities
 {
     public enum FileWriteMode
     {
         Overwrite,  // 上書きモード
         Append,     // 追記モード
-        JsonAppend  // JSON 追記モード（既存の JSON 配列に新しいオブジェクトを追加）
+        JsonAppend  // JSON追記モード（既存の JSON 配列に新しいオブジェクトを追加）
     }
 
     public class FileOutputService
     {
+        private readonly FileReadService _fileReadService;
+
+        public FileOutputService(FileReadService fileReadService)
+        {
+            _fileReadService = fileReadService;
+        }
+
         /// <summary>
-        /// 指定されたパスとファイル名に対し、内容をモードに応じて書き込みます。
+        /// 指定されたパスとファイル名に対し、内容をモードに応じて非同期に書き込みます。
         /// </summary>
         /// <param name="path">出力先ディレクトリのパス</param>
         /// <param name="fileName">出力するファイル名</param>
         /// <param name="content">書き込む内容</param>
         /// <param name="mode">書き込みモード (Overwrite, Append, JsonAppend)</param>
-        public void WriteToFile(string path, string fileName, string content, FileWriteMode mode)
+        public async Task WriteToFileAsync(string path, string fileName, string content, FileWriteMode mode)
         {
             // 出力先のディレクトリが存在しなければ作成
             if (!Directory.Exists(path))
@@ -32,19 +43,29 @@ namespace Andean.AndeanClass.Services.Utilities
             switch (mode)
             {
                 case FileWriteMode.Overwrite:
-                    File.WriteAllText(fullPath, content);
+                    await File.WriteAllTextAsync(fullPath, content);
                     break;
 
                 case FileWriteMode.Append:
-                    File.AppendAllText(fullPath, content);
+                    await File.AppendAllTextAsync(fullPath, content);
                     break;
 
                 case FileWriteMode.JsonAppend:
-                    // JSON追記モードの場合、ファイルが存在していれば既存の JSON 配列に追加、なければ新たに JSON 配列を作成
+                    string existingJson = string.Empty;
                     if (File.Exists(fullPath))
                     {
-                        var existingJson = File.ReadAllText(fullPath);
-                        JArray jsonArray;
+                        // FileReadService の関数を利用してファイル内容を読み込む
+                        existingJson = await _fileReadService.ReadFileAsync(fullPath, encoding: Encoding.UTF8, throwIfNotFound: false);
+                    }
+
+                    // 既存の JSON 配列が存在しなければ、新規配列を作成
+                    JArray jsonArray;
+                    if (string.IsNullOrWhiteSpace(existingJson))
+                    {
+                        jsonArray = new JArray();
+                    }
+                    else
+                    {
                         try
                         {
                             jsonArray = JArray.Parse(existingJson);
@@ -53,21 +74,15 @@ namespace Andean.AndeanClass.Services.Utilities
                         {
                             jsonArray = new JArray();
                         }
-                        var newObj = JObject.Parse(content);
-                        jsonArray.Add(newObj);
-                        File.WriteAllText(fullPath, jsonArray.ToString());
                     }
-                    else
-                    {
-                        var jsonArray = new JArray();
-                        var newObj = JObject.Parse(content);
-                        jsonArray.Add(newObj);
-                        File.WriteAllText(fullPath, jsonArray.ToString());
-                    }
+                    // 新たな JSON オブジェクトとして内容をパースし追加
+                    var newObj = JObject.Parse(content);
+                    jsonArray.Add(newObj);
+                    await File.WriteAllTextAsync(fullPath, jsonArray.ToString());
                     break;
 
                 default:
-                    throw new System.ArgumentException("Unknown FileWriteMode");
+                    throw new ArgumentException("Unknown FileWriteMode");
             }
         }
     }

--- a/Andean/Services/Utilities/FileReadService.cs
+++ b/Andean/Services/Utilities/FileReadService.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Andean.Services.Utilities
+{
+    public class FileReadService
+    {
+        /// <summary>
+        /// 指定されたパスのファイルを非同期に読み込みます。
+        /// </summary>
+        /// <param name="filePath">読み込み対象のファイルのパス</param>
+        /// <param name="encoding">ファイルのエンコーディング（指定がなければ UTF8 を使用）</param>
+        /// <param name="throwIfNotFound">ファイルが存在しない場合、例外をスローするか（true: スロー、false: 空文字列を返す）</param>
+        /// <param name="cancellationToken">キャンセル用の CancellationToken</param>
+        /// <returns>ファイルの内容（文字列）</returns>
+        public async Task<string> ReadFileAsync(string filePath, Encoding? encoding = null, bool throwIfNotFound = true, CancellationToken cancellationToken = default)
+        {
+            if (!File.Exists(filePath))
+            {
+                if (throwIfNotFound)
+                    throw new FileNotFoundException("ファイルが見つかりません。", filePath);
+                else
+                    return string.Empty;
+            }
+
+            encoding ??= Encoding.UTF8;
+
+            using (StreamReader reader = new StreamReader(filePath, encoding))
+            {
+                return await reader.ReadToEndAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- FileReadService.ReadFileAsync の作成
- FileOutputService の JsonAppend ブランチを改修し、既存のファイル内容読み込みに FileReadService.ReadFileAsync を使用
- 書き込み処理を非同期関数 WriteToFileAsync として実装
- これにより、コードの再利用性と保守性を向上