### PR TITLE
[Feature] ConfigService 改修：IConfiguration 連携とファイル更新機能を統合　TSK-36

### DIFF
--- a/Andean/Services/Config/ConfigService.cs
+++ b/Andean/Services/Config/ConfigService.cs
@@ -2,7 +2,8 @@
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Andean;
+using Andean.Config;
+using Andean.Utilities;
 
 namespace Andean.Config
 {
@@ -11,33 +12,80 @@ namespace Andean.Config
     /// </summary>
     public class ConfigService
     {
-        // 設定ファイルのパス（プロジェクトルートからの相対パス）
-        private readonly string _configFilePath = Path.Combine("Config", "config.json");
+        private readonly IConfiguration _configuration;
+        private readonly FileOutputService _fileOutputService;
+        private readonly string _configFilePath;
 
-        /// <summary>
-        /// config.json の内容を AppConfig 型にデシリアライズして取得します。
-        /// </summary>
-        /// <returns>AppConfig のインスタンス</returns>
-        public async Task<AppConfig> GetConfigAsync()
+        public ConfigService(IConfiguration configuration, FileOutputService fileOutputService)
         {
-            if (!File.Exists(_configFilePath))
-            {
-                throw new FileNotFoundException("Configuration file not found.", _configFilePath);
-            }
-
-            string json = await File.ReadAllTextAsync(_configFilePath);
-            return JsonSerializer.Deserialize<AppConfig>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            _configuration = configuration;
+            _fileOutputService = fileOutputService;
+            // 設定ファイルのパス（プロジェクトルートからの相対パス）
+            _configFilePath = Path.Combine("Config", "config.json");
         }
 
         /// <summary>
-        /// 指定された AppConfig オブジェクトを JSON にシリアライズして config.json に上書き保存します。
+        /// IConfiguration を利用して、config.json の内容を AppConfig 型にバインドして取得します。
+        /// (reloadOnChange により自動更新済みの値を取得可能)
         /// </summary>
-        /// <param name="config">保存する AppConfig オブジェクト</param>
+        public Task<AppConfig> GetConfigAsync()
+        {
+            // IConfiguration はすでに読み込まれているので、Task.FromResult でラップして返す
+            return Task.FromResult(_configuration.Get<AppConfig>());
+        }
+
+        /// <summary>
+        /// 指定された AppConfig オブジェクトを JSON にシリアライズし、config.json に上書き保存します。
+        /// FileOutputService の WriteToFileAsync を利用します。
+        /// </summary>
+        /// <param name="config">更新する AppConfig オブジェクト</param>
         public async Task UpdateConfigAsync(AppConfig config)
         {
             var options = new JsonSerializerOptions { WriteIndented = true };
             string json = JsonSerializer.Serialize(config, options);
-            await File.WriteAllTextAsync(_configFilePath, json);
+            await _fileOutputService.WriteToFileAsync("Config", "config.json", json, FileWriteMode.Overwrite);
+        }
+
+        /// <summary>
+        /// 指定されたセクションのみを更新して config.json を上書き保存します。
+        /// セクションキーは小文字で指定してください（例："apexlegends", "penetrator", "output", "language", "log_dir", "data_fps", "score_setting"）。
+        /// </summary>
+        /// <typeparam name="T">更新するセクションの型</typeparam>
+        /// <param name="sectionKey">更新対象のセクションキー</param>
+        /// <param name="newSection">新しい値</param>
+        public async Task UpdateConfigSectionAsync<T>(string sectionKey, T newSection)
+        {
+            // IConfiguration 経由で現在の設定を取得
+            AppConfig config = _configuration.Get<AppConfig>();
+
+            switch (sectionKey.ToLowerInvariant())
+            {
+                case "apexlegends":
+                    config.ApexLegends = newSection as ApexLegendsConfig;
+                    break;
+                case "penetrator":
+                    config.Penetrator = newSection as System.Collections.Generic.List<string>;
+                    break;
+                case "output":
+                    config.Output = newSection as string;
+                    break;
+                case "language":
+                    config.Language = newSection as string;
+                    break;
+                case "log_dir":
+                    config.Log_Dir = newSection as string;
+                    break;
+                case "data_fps":
+                    config.Data_Fps = Convert.ToInt32(newSection);
+                    break;
+                case "score_setting":
+                    config.Score_Setting = newSection as ScoreSettingConfig;
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown config section: {sectionKey}");
+            }
+
+            await UpdateConfigAsync(config);
         }
     }
 }


### PR DESCRIPTION
- IConfiguration を利用して config.json の内容を AppConfig にバインドし取得する GetConfig() を実装
- FileOutputService を用いた非同期更新機能（UpdateConfigAsync）を追加し、設定ファイルを書き換え可能に
- UpdateConfigSectionAsync<T>() を実装し、特定セクションのみを更新できるように拡張
- これにより、設定の取得は自動リロード、更新は共通ユーティリティを利用して一元管理可能に