### PR TITLE
[TimestampService] BaseClass継承によるUpdate処理への改修　TSK-141

### DIFF
--- a/Andean/Andean.csproj
+++ b/Andean/Andean.csproj
@@ -20,6 +20,7 @@
 		<Protobuf Include="ApexLiveAPI\Protos\events.proto" GrpcServices="None" />
 	</ItemGroup>
 	<ItemGroup>
+	  <Folder Include="Controllers\" />
 	  <Folder Include="output\" />
 	  <Folder Include="wwwroot\" />
 	</ItemGroup>

--- a/Andean/Program.cs
+++ b/Andean/Program.cs
@@ -1,5 +1,4 @@
 ﻿using Andean.Hubs;
-using Andean.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,6 +13,7 @@ using Andean.WebsocketServer.Services;
 using Andean.Utilities;
 using Andean.Config;
 using System.Diagnostics;
+using Andean;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -41,7 +41,7 @@ builder.Services.AddSignalR();
 builder.Services.AddSingleton<ConfigService>();
 
 // 🚀 TimestampService をシングルトンで登録
-builder.Services.AddSingleton<TimestampService>();
+builder.Services.AddSingleton<AndeanSystem, TimestampService>();
 
 // 🚀 WebSocket サーバーをシングルトンとして登録
 builder.Services.AddSingleton<WebSocketServer>();
@@ -78,6 +78,11 @@ builder.Services.AddSingleton<FileReadService>();
 
 // 🚀 FileOutputService をシングルトンで登録
 builder.Services.AddSingleton<FileOutputService>();
+
+// UpdateManager をホストサービスとして登録
+builder.Services.AddHostedService<UpdateManager>();
+
+
 
 
 // 🚀 CORS 設定: localhost:3000 からのリクエストを許可
@@ -122,9 +127,6 @@ app.MapHub<OverlayHub>("/overlayHub");                 // オーバーレイ用
 app.MapHub<OverlayControlPanelHub>("/overlayControlPanelHub"); // オーバーレイコントロールパネル用
 app.MapHub<LiveViewHub>("/liveViewHub");
 
-
-// 🚀 TimestampService をアプリ起動時に作成（タイマーを開始）
-app.Services.GetRequiredService<TimestampService>();
 
 // 🚀 WebSocket サーバーをバックグラウンドで起動
 try

--- a/Andean/Services/AndeanSystem/AndenaSystem.cs
+++ b/Andean/Services/AndeanSystem/AndenaSystem.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace Andean
+{
+    public abstract class AndeanSystem
+    {
+        // サブクラスに実装を強制する
+        public abstract void Update();
+    }
+}

--- a/Andean/Services/AndeanSystem/UpdateManager.cs
+++ b/Andean/Services/AndeanSystem/UpdateManager.cs
@@ -1,0 +1,62 @@
+﻿// UpdateManager.cs
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Andean;
+
+namespace Andean
+{
+    // IHostedService を実装してバックグラウンドで更新処理を行う
+    public class UpdateManager : IHostedService
+    {
+        // DI により、BaseClass を継承した全オブジェクトを受け取る
+        private readonly IEnumerable<AndeanSystem> _updatables;
+        private CancellationTokenSource _cts;
+
+        public UpdateManager(IEnumerable<AndeanSystem> updatables)
+        {
+            _updatables = updatables;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            // 別スレッドで更新ループを開始（60FPS = 約16.67ms毎）
+            Task.Run(() => UpdateLoop(_cts.Token));
+            return Task.CompletedTask;
+        }
+
+        private async Task UpdateLoop(CancellationToken token)
+        {
+            const int targetFPS = 60;
+            const int frameDelay = 1000 / targetFPS; // 約16ms
+
+            while (!token.IsCancellationRequested)
+            {
+                var frameStart = DateTime.UtcNow;
+
+                // 登録されたすべての更新対象の Update() を呼び出す
+                foreach (var updatable in _updatables)
+                {
+                    updatable.Update();
+                }
+
+                // 1フレーム分の処理時間を計測し、残り時間分待機
+                var elapsed = (DateTime.UtcNow - frameStart).TotalMilliseconds;
+                var delay = frameDelay - (int)elapsed;
+                if (delay > 0)
+                {
+                    await Task.Delay(delay, token);
+                }
+            }
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _cts.Cancel();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Andean/Services/TimestampService.cs
+++ b/Andean/Services/TimestampService.cs
@@ -1,49 +1,44 @@
-﻿using Andean.Hubs;
+﻿// TimestampService.cs
+using Andean.Hubs;
+using Andean;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace Andean.Services
+namespace Andean.AndeanClass.Services
 {
-    public class TimestampService
+    // TimestampService は BaseClass を継承し、Update() を実装する
+    public class TimestampService : AndeanSystem
     {
         private readonly IHubContext<ControlPanelHub> _hubContext;
-        private readonly ILogger<TimestampService> _logger; // 🚀 ログ用
-        private Timer? _timer;
-        private readonly object _lock = new();
+        private readonly ILogger<TimestampService> _logger;
+        private DateTime _lastSentTime = DateTime.MinValue;
+        private readonly TimeSpan _interval = TimeSpan.FromSeconds(5);
 
         public TimestampService(IHubContext<ControlPanelHub> hubContext, ILogger<TimestampService> logger)
         {
             _hubContext = hubContext;
-            _logger = logger; // 🚀 ログ機能を初期化
-            StartTimer();
+            _logger = logger;
+            _logger.LogInformation("TimestampService initialized using Update method.");
         }
 
-        private void StartTimer()
+        // Update() は UpdateManager により 60FPS (約16ms毎) で呼ばれる
+        public override void Update()
         {
-            lock (_lock)
+            // 前回送信から _interval 経過しているかチェック
+            if (DateTime.UtcNow - _lastSentTime >= _interval)
             {
-                if (_timer == null)
+                _lastSentTime = DateTime.UtcNow;
+                try
                 {
-                    _logger.LogInformation("⏳ タイマー開始...");
-
-                    _timer = new Timer(async _ =>
-                    {
-                        try
-                        {
-                            //_logger.LogInformation("📡 送信準備...");
-                            var timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss");
-
-                            await _hubContext.Clients.All.SendAsync("ReceiveMessage", $"Current UTC Time: {timestamp}");
-                            //_logger.LogInformation("✅ メッセージ送信完了: {Timestamp}", timestamp);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogError(ex, "❌ メッセージ送信エラー");
-                        }
-                    }, null, TimeSpan.Zero, TimeSpan.FromSeconds(5)); // 5秒ごとに送信
+                    var timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss");
+                    // 非同期送信（Update() は同期メソッドなので fire-and-forget で実行）
+                    _hubContext.Clients.All.SendAsync("ReceiveMessage", $"Current UTC Time: {timestamp}");
+                    _logger.LogInformation("Sent timestamp: {Timestamp}", timestamp);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error sending timestamp.");
                 }
             }
         }

--- a/andenui/lib/hooks/useControlPanelSignalR.ts
+++ b/andenui/lib/hooks/useControlPanelSignalR.ts
@@ -51,6 +51,7 @@ export function useControlPanelSignalR() {
     const [lobbyResponse, setLobbyResponse] = useState<string | null>(null);
     const [apexResponse, setApexResponse] = useState<string | null>(null);
     const [isLobbyLoading, setIsLobbyLoading] = useState(false);
+    const [messages, setMessages] = useState<string[]>([]);
     const [isApexLoading, setIsApexLoading] = useState(false);
 
     useEffect(() => {
@@ -86,6 +87,10 @@ export function useControlPanelSignalR() {
         newConnection.on("ReceiveStatus", response => {
             console.log("📩 Received Config Data:", response);
             setConfigData(response);
+        });
+        newConnection.on("ReceiveMessage", message => {
+            console.log("📩 Received Message:", message);
+            setMessages(prevMessages => [...prevMessages, message]);
         });
 
         setConnection(newConnection);


### PR DESCRIPTION
- Timerによる定期処理を廃止し、BaseClassを継承してUpdate()メソッド内でSignalR送信処理を実装
- Update()は60FPSで呼ばれるUpdateManagerから実行され、5秒間隔でタイムスタンプを送信
- 他サービスとの統一的な更新ループ管理を実現