### PR TITLE
Initialize packet list in CreateCustomMatch method

### DIFF
--- a/Andean/AndeanClass/Controllers/AndeanClassController.cs
+++ b/Andean/AndeanClass/Controllers/AndeanClassController.cs
@@ -24,11 +24,7 @@ namespace AndeanClass.Controllers
         /// <summary>
         /// パケット情報
         /// </summary>
-        public static Dictionary<double, Packet> _packetList = new Dictionary<double, Packet>();
-        /// <summary>
-        /// プレイヤー情報を保持する変数
-        /// </summary>
-        public static Dictionary<string, EventPlayer> _playerData = new Dictionary<string, EventPlayer>();
+        public static Dictionary<double, Packet> packetList = new Dictionary<double, Packet>();
         /// <summary>
         /// チーム順位のリスト
         /// </summary>

--- a/Andean/AndeanClass/Controllers/AndeanClassCustomMatchController.cs
+++ b/Andean/AndeanClass/Controllers/AndeanClassCustomMatchController.cs
@@ -14,12 +14,12 @@ namespace AndeanClass.Controllers
                     throw new InvalidOperationException("CustomMatchが初期化されていません。");
                 }
 
-                if (_packetList.Count == 0)
+                if (packetList.Count == 0)
                 {
                     return;
                 }
 
-                Packet packet = _packetList[_updateTime];
+                Packet packet = packetList[_updateTime];
 
                 var targetPlayerList = observerSwitchedMsg.TargetTeam;
                 Dictionary<string, int> keepedIds = new Dictionary<string, int>();

--- a/Andean/AndeanClass/Controllers/AndeanClassItemController.cs
+++ b/Andean/AndeanClass/Controllers/AndeanClassItemController.cs
@@ -45,7 +45,7 @@ namespace AndeanClass.Controllers
                 Event _event = new Event(Msg.Timestamp, Msg.Category, eventData);
 
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
         public static void ProcessInventoryDrop(Rtech.Liveapi.InventoryDrop Msg)
@@ -67,7 +67,7 @@ namespace AndeanClass.Controllers
                 Event _event = new Event(Msg.Timestamp, Msg.Category, eventData);
 
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
         public static void ProcessInventoryUse(Rtech.Liveapi.InventoryUse Msg)
@@ -133,7 +133,7 @@ namespace AndeanClass.Controllers
                 Event _event = new Event(Msg.Timestamp, Msg.Category, eventData);
 
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
         public static void ProcessGrenadeThrown(Rtech.Liveapi.GrenadeThrown Msg)
@@ -163,7 +163,7 @@ namespace AndeanClass.Controllers
 
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
         public static void ProcessBlackMarketAction(Rtech.Liveapi.BlackMarketAction Msg)
@@ -197,7 +197,7 @@ namespace AndeanClass.Controllers
 
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
 
@@ -226,7 +226,7 @@ namespace AndeanClass.Controllers
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
 
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
     }

--- a/Andean/AndeanClass/Controllers/AndeanClassPlayerController.cs
+++ b/Andean/AndeanClass/Controllers/AndeanClassPlayerController.cs
@@ -46,9 +46,9 @@ namespace AndeanClass.Controllers
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
                 
                 _match.AddEventElement(_event);
-                if (_packetList.Count > 0)
+                if (packetList.Count > 0)
                 {
-                    _packetList[_updateTime].AddEvent(_event);
+                    packetList[_updateTime].AddEvent(_event);
                 }
             }
         }
@@ -69,9 +69,9 @@ namespace AndeanClass.Controllers
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
 
                 _match.AddEventElement(_event);
-                if (_packetList.Count > 0)
+                if (packetList.Count > 0)
                 {
-                    _packetList[_updateTime].AddEvent(_event);
+                    packetList[_updateTime].AddEvent(_event);
                 }
             }
         }
@@ -90,7 +90,7 @@ namespace AndeanClass.Controllers
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
 
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
         public static void ProcessPlayerUltimateCharged(Rtech.Liveapi.PlayerUltimateCharged Msg)
@@ -111,7 +111,7 @@ namespace AndeanClass.Controllers
 
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
         public static void ProcessPlayerUpgradeTierChanged(Rtech.Liveapi.PlayerUpgradeTierChanged Msg)
@@ -130,7 +130,7 @@ namespace AndeanClass.Controllers
 
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
         public static void ProcessPlayerDamaged(Rtech.Liveapi.PlayerDamaged Msg)
@@ -183,7 +183,7 @@ namespace AndeanClass.Controllers
 
                 _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
       
@@ -239,7 +239,7 @@ namespace AndeanClass.Controllers
                 _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
 
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
       
@@ -293,7 +293,7 @@ namespace AndeanClass.Controllers
                 _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
 
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
       
@@ -343,7 +343,7 @@ namespace AndeanClass.Controllers
                 _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
 
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
         public static void ProcessGibraltarShieldAbsorbed(Rtech.Liveapi.GibraltarShieldAbsorbed Msg)
@@ -401,7 +401,7 @@ namespace AndeanClass.Controllers
                 _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
 
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
       
@@ -459,7 +459,7 @@ namespace AndeanClass.Controllers
                 _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
 
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
       
@@ -488,7 +488,7 @@ namespace AndeanClass.Controllers
 
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
       
@@ -513,7 +513,7 @@ namespace AndeanClass.Controllers
 
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
         public static void ProcessLegendUpgradeSelected(Rtech.Liveapi.LegendUpgradeSelected Msg)
@@ -547,7 +547,7 @@ namespace AndeanClass.Controllers
 
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
       
@@ -570,7 +570,7 @@ namespace AndeanClass.Controllers
 
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
       
@@ -591,7 +591,7 @@ namespace AndeanClass.Controllers
 
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
         public static void ProcessWarpGateUsed(Rtech.Liveapi.WarpGateUsed Msg)
@@ -611,7 +611,7 @@ namespace AndeanClass.Controllers
 
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
         public static void ProcessWeaponSwitched(Rtech.Liveapi.WeaponSwitched Msg)
@@ -632,9 +632,9 @@ namespace AndeanClass.Controllers
 
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
                 _match.AddEventElement(_event);
-                if (_packetList.Count > 0)
+                if (packetList.Count > 0)
                 {
-                    _packetList[_updateTime].AddEvent(_event);
+                    packetList[_updateTime].AddEvent(_event);
                 }
             }
         }
@@ -680,7 +680,7 @@ namespace AndeanClass.Controllers
 
                 Event _event = new Event(Msg.Timestamp, Msg.Category, _eventData);
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
 
@@ -708,7 +708,7 @@ namespace AndeanClass.Controllers
 
                 // イベントデータの追加
                 _match.AddEventElement(_event);
-                _packetList[_updateTime].AddEvent(_event);
+                packetList[_updateTime].AddEvent(_event);
             }
         }
     }

--- a/Andean/AndeanClass/Controllers/AndeanClassUpdateController.cs
+++ b/Andean/AndeanClass/Controllers/AndeanClassUpdateController.cs
@@ -23,7 +23,7 @@ namespace AndeanClass.Controllers
                 _updateTime = (double)now / 1000 - _match.StartTimeStamp;
 
                 // 新たなPacketオブジェクトを生成し、_packetListに追加
-                _packetList[_updateTime] = new Packet(_updateTime);
+                packetList[_updateTime] = new Packet(_updateTime);
             }
             else
             {

--- a/Andean/AndeanClass/Controllers/AndeanClassUpdateController.cs
+++ b/Andean/AndeanClass/Controllers/AndeanClassUpdateController.cs
@@ -20,10 +20,10 @@ namespace AndeanClass.Controllers
                 if (ControlPanelHubService.ObserverSwitchEnabled && _match.State == StringPool.Get("Playing"))
                     await GetPlayerStatus(_match);
 
-                // 新たなPacketオブジェクトを生成し、_packetListに追加
-                _packetList[now] = new Packet((double)now / 1000 - _match.StartTimeStamp);
+                _updateTime = (double)now / 1000 - _match.StartTimeStamp;
 
-                _updateTime = now;
+                // 新たなPacketオブジェクトを生成し、_packetListに追加
+                _packetList[_updateTime] = new Packet(_updateTime);
             }
             else
             {

--- a/Andean/AndeanClass/Services/MatchService.cs
+++ b/Andean/AndeanClass/Services/MatchService.cs
@@ -25,11 +25,6 @@ namespace AndeanClass.Services
             _match = new CustomMatch(formattedDate);
             _match.SetGameVersion(initMsg.GameVersion);
             Console.WriteLine($"[MatchService] CustomMatch 初期化完了：{formattedDate}");
-
-            // パケットリストを初期化
-            _packetList = new Dictionary<double, Packet>();
-            // プレイヤーデータを初期化
-            _playerData = new Dictionary<string, EventPlayer>();
         }
 
         // 共通のマッチセットアップ処理
@@ -142,8 +137,11 @@ namespace AndeanClass.Services
             {
                 ControlPanelHubService.SetLiveAPIStatus("LobbyJoin", "InLobby").Wait();
 
+                // プレイヤーのPOSデータを一時的に保存するためのリストを作成
+                Dictionary<string, EventPlayer> playerData = new Dictionary<string, EventPlayer>();
+
                 // Packetを確認し、整形して保存する
-                foreach (var packet in _packetList.OrderBy(kvp => kvp.Key).Select(kvp => kvp.Value))
+                foreach (var packet in packetList.OrderBy(kvp => kvp.Key).Select(kvp => kvp.Value))
                 {
                     // パケットを更新する
                     if ((packet.Data.Count + packet.Events.Count) != 0 && packet.T > 2)
@@ -155,7 +153,7 @@ namespace AndeanClass.Services
                         //     {
                         //         // 最初のイベントのtimestampから試合開始時刻を引く
                         //         packet.T = packet.Events[0].Timestamp - _match.StartTimeStamp;
-                        //         CheckPacketData(packet, _playerData);
+                        //         CheckPacketData(packet, playerData);
                         //         _match.AddPacketElement(packet.T.ToString(), (JObject)packet.ToJson());
                         //     }
                         //     else
@@ -165,14 +163,19 @@ namespace AndeanClass.Services
                         // }
                         // else
                         // {
-                        //     CheckPacketData(packet, _playerData);
+                        //     CheckPacketData(packet, playerData);
                         //     _match.AddPacketElement(packet.T.ToString(), (JObject)packet.ToJson());
                         // }
 
-                        MatchUtilities.CheckPacketData(packet, _playerData);
+                        MatchUtilities.CheckPacketData(packet, playerData);
                         _match.AddPacketElement(packet.T.ToString(), packet.ToShortPacket());
                     }
                 }
+
+                // パケットリストを初期化
+                packetList.Clear();
+                // プレイヤーデータを初期化
+                playerData.Clear();
 
                 // _ringEvents を 2 つずつ処理する
                 for (int i = 0; i < _ringEvents.Count; i += 2)
@@ -266,7 +269,7 @@ namespace AndeanClass.Services
 
             Event _event = new Event(matchStateEndMsg.Timestamp, matchStateEndMsg.Category, _eventData);
             _match.AddEventElement(_event);
-            _packetList[_updateTime].AddEvent(_event);
+            packetList[_updateTime].AddEvent(_event);
         }
 
         public static void ProcessTeamEliminated(SquadEliminated squadEliminatedMsg)
@@ -303,7 +306,7 @@ namespace AndeanClass.Services
             };
             Event _event = new Event(squadEliminatedMsg.Timestamp, squadEliminatedMsg.Category, _eventData);
             _match.AddEventElement(_event);
-            _packetList[_updateTime].AddEvent(_event);
+            packetList[_updateTime].AddEvent(_event);
         }
         public static void ProcessRingStartClosing(RingStartClosing ringStartClosingMsg)
         {
@@ -337,7 +340,7 @@ namespace AndeanClass.Services
             Event _event = new Event(ringStartClosingMsg.Timestamp, ringStartClosingMsg.Category, _eventData);
             _match.AddEventElement(_event);
 
-            Packet packet = _packetList[_updateTime];
+            Packet packet = packetList[_updateTime];
 
             // AndeanのPacketクラスに追加する
             packet.AddEvent(_event);
@@ -378,7 +381,7 @@ namespace AndeanClass.Services
             Event _event = new Event(ringFinishedClosingMsg.Timestamp, ringFinishedClosingMsg.Category, _eventData);
             _match.AddEventElement(_event);
 
-            Packet packet = _packetList[_updateTime];
+            Packet packet = packetList[_updateTime];
 
             // AndeanのPacketクラスに追加する
             packet.AddEvent(_event);

--- a/Andean/AndeanClass/Services/MatchService.cs
+++ b/Andean/AndeanClass/Services/MatchService.cs
@@ -25,6 +25,9 @@ namespace AndeanClass.Services
             _match = new CustomMatch(formattedDate);
             _match.SetGameVersion(initMsg.GameVersion);
             Console.WriteLine($"[MatchService] CustomMatch 初期化完了：{formattedDate}");
+
+            // パケットリストを初期化
+            _packetList = new Dictionary<double, Packet>();
         }
 
         // 共通のマッチセットアップ処理

--- a/Andean/AndeanClass/Services/MatchService.cs
+++ b/Andean/AndeanClass/Services/MatchService.cs
@@ -28,6 +28,8 @@ namespace AndeanClass.Services
 
             // パケットリストを初期化
             _packetList = new Dictionary<double, Packet>();
+            // プレイヤーデータを初期化
+            _playerData = new Dictionary<string, EventPlayer>();
         }
 
         // 共通のマッチセットアップ処理


### PR DESCRIPTION
This pull request introduces an enhancement to the `CreateCustomMatch` method in `MatchService.cs` by initializing a new `_packetList` dictionary to manage packets. This change improves the method's functionality by preparing it to handle packet-related data.

Key change:

* [`Andean/AndeanClass/Services/MatchService.cs`](diffhunk://#diff-19d6c9d8e4bbad220d4b3f52793bbd6ea2b7469b48335a5dec45f8e3c2bcb738R28-R30): Added initialization of `_packetList` as a `Dictionary<double, Packet>` within the `CreateCustomMatch` method to support packet management.